### PR TITLE
Use Build Args over Volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM ubuntu:18.04
 
 MAINTAINER Sasha Fox "sashanullptr@gmail.com"
 
+ARG APP_ROOT_DIR
+ARG FLASK_ROOT_FILE
+ARG WSGI_FILE
+
 RUN apt-get update
 
 # Install basic build requirements.
@@ -19,10 +23,16 @@ COPY ./apache2_files/app.conf ./app_files/app.conf
 RUN mv ./app_files/app.conf /etc/apache2/sites-available/000-default.conf
 RUN rm -r ./app_files
 
+RUN pip3 install flask flask_cors
+
+COPY $APP_ROOT_DIR /var/www/app/
+RUN pip3 install /var/www/app/
+
+COPY $FLASK_ROOT_FILE /var/www/app/flask_app.py
+COPY $WSGI_FILE /var/www/wsgi_scripts/app.wsgi
+
 RUN a2enmod rewrite
 RUN service apache2 restart
-
-RUN pip3 install flask flask_cors
 
 # Since we'll be mapping things to 000-default.conf via docker volumes we need
 # to enable and disable the site to trigger a refresh.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,10 @@ services:
     restart: always
     image: flask_app:latest
     build: .
+      args:
+        ARG APP_ROOT_DIR : ./example_app
+        ARG FLASK_ROOT_FILE: ./flask_app.py
+        ARG WSGI_FILE: ./apache2_files/app.wsgi
     networks:
       - external_network
     healthcheck:
@@ -14,11 +18,6 @@ services:
         retries: 5
     ports:
       - 5000:80
-    volumes:
-      - ./example_app:/var/www/app/example_app
-      - ./flask_app.py:/var/www/app/flask_app.py
-      - ./apache2_files/app.wsgi:/var/www/wsgi_scripts/app.wsgi
-      # - ./apache2_files/app.conf:/etc/apache2/sites-available/000-default.conf
 
 networks:
   external_network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,9 @@ services:
     image: flask_app:latest
     build: .
       args:
-        ARG APP_ROOT_DIR : ./example_app
-        ARG FLASK_ROOT_FILE: ./flask_app.py
-        ARG WSGI_FILE: ./apache2_files/app.wsgi
+        APP_ROOT_DIR : ./example_app
+        FLASK_ROOT_FILE: ./flask_app.py
+        WSGI_FILE: ./apache2_files/app.wsgi
     networks:
       - external_network
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,10 @@ services:
   flask:
     restart: always
     image: flask_app:latest
-    build: .
+    build:
+      context: ./
       args:
-        APP_ROOT_DIR : ./example_app
+        APP_ROOT_DIR: ./example_app
         FLASK_ROOT_FILE: ./flask_app.py
         WSGI_FILE: ./apache2_files/app.wsgi
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     build:
       context: ./
       args:
-        APP_ROOT_DIR: ./example_app
+        APP_ROOT_DIR: ./
         FLASK_ROOT_FILE: ./flask_app.py
         WSGI_FILE: ./apache2_files/app.wsgi
     networks:


### PR DESCRIPTION
This PR refactors away from "map all app data with Docker volumes" pattern established in #1 . In lieu of using volumes Flask/Apache2 files are copied into containers at build time via build args.

These changes greatly decouples the host system from the container but mean that containers _cannot_ be built in advance.