### PR TITLE
Support arbitrary Apache2 conf files.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
 README.md
 LICENSE
 .git
+.gitignore
+Dockerfile
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER Sasha Fox "sashanullptr@gmail.com"
 ARG APP_ROOT_DIR
 ARG FLASK_ROOT_FILE
 ARG WSGI_FILE
+ARG APACHE_CONF="./apache2_files/app.conf"
 
 RUN apt-get update
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get install -y apache2 apache2-dev apache2-utils ssl-cert
 # Install mod-WSGI for apache2
 RUN apt-get install -y libapache2-mod-wsgi-py3
 
-COPY ./apache2_files/app.conf ./app_files/app.conf
+COPY $APACHE_CONF ./app_files/app.conf
 RUN mv ./app_files/app.conf /etc/apache2/sites-available/000-default.conf
 RUN rm -r ./app_files
 

--- a/README.md
+++ b/README.md
@@ -86,9 +86,10 @@ services:
   flask:
     restart: always
     image: flask_app:latest
-    build: .
+    build:
+      context: ./
       args:
-        APP_ROOT_DIR: ./example_app
+        APP_ROOT_DIR: ./
         FLASK_ROOT_FILE: ./flask_app.py
         WSGI_FILE: ./apache2_files/app.wsgi
         APACHE_CONF: ./apache2_files/app.conf
@@ -107,6 +108,7 @@ networks:
     driver: bridge
     ipam:
       driver: default
+
 ```
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ following *must* be specified at build time.
 | APP_ROOT_DIR    | Project root directory                    |
 | FLASK_ROOT_FILE | Root Flask app Python file                |
 | WSGI_FILE       | WSGI file that references FLASK_ROOT_FILE |
+| APACHE_CONF     | Apache2 `.conf` file                       |
 
 For example if our Flask app had the following layout:
 
@@ -27,6 +28,7 @@ For example if our Flask app had the following layout:
 .
 ├── Dockerfile
 ├── apache2_files
+│   └── app.conf
 │   └── app.wsgi
 ├── example_app
 │   ├── __init__.py
@@ -41,6 +43,7 @@ We'd want our build args set up like so:
 | APP_ROOT_DIR    | ./example_app            |
 | FLASK_ROOT_FILE | ./flask_app.py           |
 | WSGI_FILE       | ./apache2_files/app.wsgi |
+| APACHE_CONF     | ./apache2_files/app.conf |
 
 ## Build The Docker Image
 
@@ -52,6 +55,7 @@ docker build -dt \
   --build-arg APP_ROOT_DIR="./example_app" \
   --build-arg FLASK_ROOT_FILE="./flask_app.py" \
   --build-arg WSGI_FILE="./apache2_files/app.wsgi" \
+  --build-arg APACHE_CONF="./apache2_files/app.conf" \
   --name flask-app \
   .
 ```

--- a/README.md
+++ b/README.md
@@ -88,9 +88,10 @@ services:
     image: flask_app:latest
     build: .
       args:
-        ARG APP_ROOT_DIR : ./example_app
-        ARG FLASK_ROOT_FILE: ./flask_app.py
-        ARG WSGI_FILE: ./apache2_files/app.wsgi
+        APP_ROOT_DIR: ./example_app
+        FLASK_ROOT_FILE: ./flask_app.py
+        WSGI_FILE: ./apache2_files/app.wsgi
+        APACHE_CONF: ./apache2_files/app.conf
     networks:
       - external_network
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     build:
       context: ./
       args:
-        APP_ROOT_DIR: ./example_app
+        APP_ROOT_DIR: ./
         FLASK_ROOT_FILE: ./flask_app.py
         WSGI_FILE: ./apache2_files/app.wsgi
         APACHE_CONF: ./apache2_files/app.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,10 @@ services:
     build:
       context: ./
       args:
-        APP_ROOT_DIR: ./
+        APP_ROOT_DIR: ./example_app
         FLASK_ROOT_FILE: ./flask_app.py
         WSGI_FILE: ./apache2_files/app.wsgi
+        APACHE_CONF: ./apache2_files/app.conf
     networks:
       - external_network
     healthcheck:


### PR DESCRIPTION
This PR resolves #4 .

A new build-arg named `APACHE_CONF` that specifies the path to apcahe2 `.conf` files has been added to the Dockerfile. Documentation had been updated to show this arg in use.

I opted _not_ to have this argument default to any particular path. However the example config file in `/apache2_files/app.conf` is still included with the project and mentioned in documentation examples.